### PR TITLE
Don't require aggregations until its used

### DIFF
--- a/lib/hydra/pcdm.rb
+++ b/lib/hydra/pcdm.rb
@@ -1,11 +1,7 @@
-require 'hydra/pcdm/version'
-require 'hydra/pcdm/vocab/pcdm_terms'
-require 'active_fedora/aggregation'
-
 module Hydra::PCDM
 
   # vocabularies
-  autoload :PCDMTerms,              'hydra/pcdm/vocab/pcdm_terms'
+  autoload :RDFVocabularies,        'hydra/pcdm/vocab/pcdm_terms'
 
   # models
   autoload :Collection,             'hydra/pcdm/models/collection'

--- a/lib/hydra/pcdm/models/collection.rb
+++ b/lib/hydra/pcdm/models/collection.rb
@@ -1,3 +1,5 @@
+require 'active_fedora/aggregation'
+
 module Hydra::PCDM
   class Collection < ActiveFedora::Base
     type RDFVocabularies::PCDMTerms.Collection  # TODO switch to using generated vocabulary when ready

--- a/lib/hydra/pcdm/models/object.rb
+++ b/lib/hydra/pcdm/models/object.rb
@@ -1,3 +1,4 @@
+require 'active_fedora/aggregation'
 module Hydra::PCDM
   class Object < ActiveFedora::Base
     type RDFVocabularies::PCDMTerms.Object  # TODO switch to using generated vocabulary when ready


### PR DESCRIPTION
This makes it so that builds such as sufia have time to load their
dependencies before trying to require.

See https://travis-ci.org/projecthydra/sufia/jobs/61206708