### PR TITLE
Use containerized builds to speed up travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: ruby
+cache: bundler
+sudo: false
 bundler_args: --without debug
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 rvm:
   - 2.1
   - 2.2


### PR DESCRIPTION
Don't build libxml2 and libxslt that are bundled with nokogiri