### PR TITLE
Define Hydra if it doesn't exist

### DIFF
--- a/lib/hydra/pcdm.rb
+++ b/lib/hydra/pcdm.rb
@@ -1,27 +1,28 @@
-module Hydra::PCDM
+module Hydra
+  module PCDM
 
-  # vocabularies
-  autoload :RDFVocabularies,        'hydra/pcdm/vocab/pcdm_terms'
+    # vocabularies
+    autoload :RDFVocabularies,        'hydra/pcdm/vocab/pcdm_terms'
 
-  # models
-  autoload :Collection,             'hydra/pcdm/models/collection'
-  autoload :Object,                 'hydra/pcdm/models/object'
-  autoload :File,                   'hydra/pcdm/models/file'
+    # models
+    autoload :Collection,             'hydra/pcdm/models/collection'
+    autoload :Object,                 'hydra/pcdm/models/object'
+    autoload :File,                   'hydra/pcdm/models/file'
 
 
-  def self.class_from_string(class_name, container_class=Kernel)
-    container_class = container_class.name if container_class.is_a? Module
-    container_parts = container_class.split('::')
-    (container_parts + class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
-      if mod == Kernel
-        Object.const_get(class_name)
-      elsif mod.const_defined? class_name.to_sym
-        mod.const_get(class_name)
-      else
-        container_parts.pop
-        class_from_string(class_name, container_parts.join('::'))
+    def self.class_from_string(class_name, container_class=Kernel)
+      container_class = container_class.name if container_class.is_a? Module
+      container_parts = container_class.split('::')
+      (container_parts + class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
+        if mod == Kernel
+          Object.const_get(class_name)
+        elsif mod.const_defined? class_name.to_sym
+          mod.const_get(class_name)
+        else
+          container_parts.pop
+          class_from_string(class_name, container_parts.join('::'))
+        end
       end
     end
   end
-
 end


### PR DESCRIPTION
Fixes:
lib/hydra/pcdm.rb:1:in `<top (required)>': uninitialized constant
Hydra (NameError)