### PR TITLE
Remove tests for descriptive and access metadata

### DIFF
--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -189,7 +189,7 @@ describe Hydra::PCDM::Collection do
       expect(collection1.objects).to eq []
     end
 
-    it 'should return empty array when only collections are aggregated' do      
+    it 'should return empty array when only collections are aggregated' do
       collection1.collections = [collection2,collection3]
       collection1.save
       expect(collection1.objects).to eq []
@@ -202,21 +202,4 @@ describe Hydra::PCDM::Collection do
       expect(collection1.objects).to eq [object1,object2]
     end
   end
-
-  describe '#METHOD_TO_SET_METADATA' do
-    xit 'should be able to set descriptive metadata' do
-      #   6) Hydra::PCDM::Collection can have descriptive metadata
-
-      # TODO Write test
-
-    end
-
-    xit 'should be able to set access metadata' do
-      #   7) Hydra::PCDM::Collection can have access metadata
-
-      # TODO Write test
-
-    end
-  end
-
 end

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -86,23 +86,4 @@ describe 'Hydra::PCDM::Object' do
 
     end
   end
-
-
-
-  describe '#METHOD_TO_SET_METADATA' do
-    xit 'should be able to set descriptive metadata' do
-      #   6) Hydra::PCDM::Collection can have descriptive metadata
-
-      # TODO Write test
-
-    end
-
-    xit 'should be able to set access metadata' do
-      #   7) Hydra::PCDM::Object can have descriptive metadata
-
-      # TODO Write test
-
-    end
-  end
-
 end


### PR DESCRIPTION
That functionality lives in ActiveFedora and Hyra::AccessControls.
We don't need to test for it here.

See #53 for further discussion of where ACLs belong.