### PR TITLE
Requrires in the files where they're needed

### DIFF
--- a/lib/hydra/pcdm/models/collection.rb
+++ b/lib/hydra/pcdm/models/collection.rb
@@ -1,5 +1,3 @@
-require 'active_fedora/aggregation'
-
 module Hydra::PCDM
   class Collection < ActiveFedora::Base
     include Hydra::PCDM::CollectionBehavior

--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -1,3 +1,5 @@
+require 'active_fedora/aggregation'
+
 module Hydra::PCDM
   module CollectionBehavior
     extend ActiveSupport::Concern

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -1,3 +1,5 @@
+require 'active_fedora/aggregation'
+
 module Hydra::PCDM
   module ObjectBehavior
     extend ActiveSupport::Concern

--- a/lib/hydra/pcdm/models/object.rb
+++ b/lib/hydra/pcdm/models/object.rb
@@ -1,5 +1,3 @@
-require 'active_fedora/aggregation'
-
 module Hydra::PCDM
   class Object < ActiveFedora::Base
     include Hydra::PCDM::ObjectBehavior


### PR DESCRIPTION
Otherwise if you're using the behaviors, e.g.:
```ruby
class Book < ActiveFedora::Base
  include Hydra::PCDM::ObjectBehavior
end
```

You'll get:
```
NoMethodError: undefined method `aggregates' for Book:Class
```