### PR TITLE
remove todo comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Reference:  [Portland Common Data Model](https://wiki.duraspace.org/x/9IoOB)
 
 To test the model and provide clarity we have included a sample mode that exercises the interfaces provided by the gem.
 The sample model may change over time to reflect the state of the gam and what it supports.  
-(TODO: Currently there is no code in the gem so it does not support any model including the example.)
+
 ![Sandwich Objet Model](https://docs.google.com/drawings/d/1wI4H3AH9pdIPllKIMO356c1cFHUN57azDlgIqMVODSw/pub?w=1369&h=727)
 
 ## Usage
@@ -78,10 +78,9 @@ c1.members = [b1]
 # c1.members << b1 # This should work in the future
 c1.save
 
-# This section waiting on https://github.com/projecthydra-labs/hydra-pcdm/pull/52
-# f1 = b1.files.build
-# f1.conent = "The quick brown fox jumped over the lazy dog."
-# b1.save
+f1 = b1.files.build
+f1.content = "The quick brown fox jumped over the lazy dog."
+b1.save
 ```
 
 ## How to contribute

--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -33,13 +33,11 @@ module Hydra::PCDM
 
     def << arg
 
-      # TODO This fails.  Tests using << operator are marked xit.
+      # TODO: Not sure how to handle coll1.collections << new_collection.  (see issue #45)
+      #       Want to override << on coll1.collections to check that new_collection passes Hydra::PCDM.collection?
+      # TODO: Not sure how to handle coll1.objects << new_object.  (see issue #45)
+      #       Want to override << on coll1.objects to check that new_object passes Hydra::PCDM.object?
 
-      # TODO: Not sure how to handle coll1.collections << new_collection and coll1.objects << new_object.
-      #       Want to override << on coll1.collections to check that new_collection is_a? Hydra::PCDM::Collection
-      #       Want to override << on coll1.objects to check that new_object is_a? Hydra::PCDM::Object
-
-      # check that arg is an instance of Hydra::PCDM::Collection or Hydra::PCDM::Object
       raise ArgumentError, "argument must be either a Hydra::PCDM::Collection or Hydra::PCDM::Object" unless
           ( Hydra::PCDM.collection? arg ) || ( Hydra::PCDM.object? arg )
       members << arg
@@ -85,12 +83,6 @@ module Hydra::PCDM
       end
       false
     end
-
-    # TODO: RDF metadata can be added using property definitions.
-    #   * How to distinguish between descriptive and access metadata?
-    #   * Are there any default properties to set for Collection's descriptive metadata?
-    #   * Are there any default properties to set for Collection's access metadata?
-    #   * Is there a way to override default properties defined in this class?
 
   end
 end

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -39,12 +39,9 @@ module Hydra::PCDM
 
     def << arg
 
-      # TODO This fails.  Tests using << operator are marked xit.
+      # TODO: Not sure how to handle obj1.objects << new_object.  (see issue #45)
+      #       Want to override << on obj1.objects to check that new_object passes Hydra::PCDM.object?
 
-      # TODO: Not sure how to handle obj1.objects << new_object.
-      #       Want to override << on obj1.objects to check that new_object is_a? Hydra::PCDM::Object
-
-      # check that arg is an instance of Hydra::PCDM::Object or Hydra::PCDM::File
       raise ArgumentError, "argument must be either a pcdm object or a pcdm file" unless
           ( Hydra::PCDM.object? arg ) || ( Hydra::PCDM.file? arg )
       members << arg  if Hydra::PCDM.object? arg
@@ -89,14 +86,6 @@ module Hydra::PCDM
           files.all? { |f| Hydra::PCDM.file? f }
       super(files)
     end
-
-    # TODO: implement hasRelatedFiles
-
-    # TODO: RDF metadata can be added using property definitions.
-    #   * How to distinguish between descriptive and access metadata?
-    #   * Are there any default properties to set for Object's descriptive metadata?
-    #   * Are there any default properties to set for Object's access metadata?
-    #   * Is there a way to override default properties defined in this class?
 
   end
 end

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -27,21 +27,11 @@ describe Hydra::PCDM::Collection do
   #   7) Hydra::PCDM::Collection can have access metadata
 
 
-  # TODO need test to validate type is Hydra::PCDM::Collection
-  # TODO need test for 3) Hydra::PCDM::Collection can aggregate (ore:aggregates) Hydra::PCDM::Object
-
   describe '#collections=' do
     it 'should aggregate collections' do
       collection1.collections = [collection2, collection3]
       collection1.save
       expect(collection1.collections).to eq [collection2, collection3]
-    end
-
-    xit 'should add a collection to the collections aggregation' do
-      collection1.collections = [collection2,collection3]
-      collection1.save
-      collection1.collections << collection4
-      expect(collection1.collections).to eq [collection2, collection3, collection4]
     end
 
     it 'should aggregate collections in a sub-collection of a collection' do
@@ -181,13 +171,6 @@ describe Hydra::PCDM::Collection do
       collection1.objects = [object1,object2]
       collection1.save
       expect(collection1.objects).to eq [object1,object2]
-    end
-
-    xit 'should add an object to the objects aggregation' do
-      collection1.objects = [object1,object2]
-      collection1.save
-      collection1.objects << object3
-      expect(collection1.objects).to eq [object1,object2,object3]
     end
 
     context "with unacceptable objects" do

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -47,13 +47,6 @@ describe Hydra::PCDM::Object do
       end
     end
 
-    xit 'should add an object to the objects aggregation' do
-      object1.objects = [object2,object3]
-      object1.save
-      object1.objects << object4
-      expect(object1.objects).to eq [object2,object3,object4]
-    end
-
     it 'should aggregate objects in a sub-object of a object' do
       object1.objects = [object2]
       object1.save
@@ -187,12 +180,6 @@ describe Hydra::PCDM::Object do
     subject { described_class.find(object.id).files }
 
     it { is_expected.to eq [file1, file2] }
-  end
-
-  describe 'Related files' do
-    xit 'should allow related files' do
-      # TODO Write test
-    end
   end
 
 end


### PR DESCRIPTION
Also removed pending tests that should be added when the functionality they are related to is added to the code base.  All removed items were either already addressed or have outstanding tickets.  There were a couple of TODOs that were not removed, but they are marked with the issue number that is addressing that TODO.