### PR TITLE
Rename #collections to child_collections

### DIFF
--- a/lib/hydra/pcdm.rb
+++ b/lib/hydra/pcdm.rb
@@ -1,5 +1,8 @@
+require 'active_support'
+
 module Hydra
   module PCDM
+    extend ActiveSupport::Autoload
 
     # vocabularies
     autoload :RDFVocabularies,        'hydra/pcdm/vocab/pcdm_terms'
@@ -15,7 +18,8 @@ module Hydra
     autoload :CollectionBehavior,     'hydra/pcdm/models/concerns/collection_behavior'
     autoload :ObjectBehavior,         'hydra/pcdm/models/concerns/object_behavior'
 
-    autoload :Indexer,                'hydra/pcdm/indexer'
+    autoload :CollectionIndexer
+    autoload :ObjectIndexer
 
     # collection services
     autoload :AddCollectionToCollection,         'hydra/pcdm/services/collection/add_collection'

--- a/lib/hydra/pcdm/collection_indexer.rb
+++ b/lib/hydra/pcdm/collection_indexer.rb
@@ -1,0 +1,12 @@
+module Hydra::PCDM
+  class CollectionIndexer < ObjectIndexer
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+        solr_doc["members_ssim"]        = object.member_ids
+        solr_doc["child_collections_ssim"] = object.child_collections.map { |o| o.id }
+      end
+    end
+
+  end
+end

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -21,7 +21,7 @@ module Hydra::PCDM
 
     module ClassMethods
       def indexer
-        Hydra::PCDM::Indexer
+        Hydra::PCDM::ObjectIndexer
       end
     end
 

--- a/lib/hydra/pcdm/object_indexer.rb
+++ b/lib/hydra/pcdm/object_indexer.rb
@@ -1,10 +1,8 @@
 module Hydra::PCDM
-  class Indexer < ActiveFedora::IndexingService
-
+  class ObjectIndexer < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc["objects_ssim"]     = object.objects.map { |o| o.id }
-        solr_doc["collections_ssim"] = object.collections.map { |o| o.id } unless Hydra::PCDM.object?(object)
       end
     end
 

--- a/lib/hydra/pcdm/services/collection/get_collections.rb
+++ b/lib/hydra/pcdm/services/collection/get_collections.rb
@@ -11,7 +11,7 @@ module Hydra::PCDM
     def self.call( parent_collection )
       raise ArgumentError, "parent_collection must be a pcdm collection" unless Hydra::PCDM.collection? parent_collection
 
-      parent_collection.collections
+      parent_collection.child_collections
     end
 
   end

--- a/spec/hydra/pcdm/collection_indexer_spec.rb
+++ b/spec/hydra/pcdm/collection_indexer_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Hydra::PCDM::CollectionIndexer do
+  let(:collection) { Hydra::PCDM::Collection.new }
+  let(:child_collections1) { Hydra::PCDM::Collection.new(id: '123') }
+  let(:child_collections2) { Hydra::PCDM::Collection.new(id: '456') }
+  let(:object1) { Hydra::PCDM::Object.new(id: '789') }
+  let(:indexer) { described_class.new(collection) }
+
+  before do
+    allow(collection).to receive(:child_collections).and_return([child_collections1, child_collections2])
+    allow(collection).to receive(:objects).and_return([object1])
+    allow(collection).to receive(:member_ids).and_return(['123', '456', '789'])
+  end
+
+  describe "#generate_solr_document" do
+    subject { indexer.generate_solr_document }
+
+    it "has fields" do
+      expect(subject['child_collections_ssim']).to eq ['123', '456']
+      expect(subject['objects_ssim']).to eq ['789']
+      expect(subject['members_ssim']).to eq ['123', '456', '789']
+    end
+  end
+end
+

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -55,7 +55,7 @@ describe Hydra::PCDM::Object do
       end
 
       subject { Foo.indexer }
-      it { is_expected.to eq Hydra::PCDM::Indexer }
+      it { is_expected.to eq Hydra::PCDM::ObjectIndexer }
     end
 
     context "when overridden with AS::Concern" do

--- a/spec/hydra/pcdm/object_indexer_spec.rb
+++ b/spec/hydra/pcdm/object_indexer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Hydra::PCDM::ObjectIndexer do
+  let(:object) { Hydra::PCDM::Object.new }
+  let(:subobject1) { Hydra::PCDM::Object.new(id: '123') }
+  let(:subobject2) { Hydra::PCDM::Object.new(id: '456') }
+  let(:indexer) { described_class.new(object) }
+
+  before do
+    allow(object).to receive(:objects).and_return([subobject1, subobject2])
+  end
+
+  describe "#generate_solr_document" do
+    subject { indexer.generate_solr_document }
+
+    it "has fields" do
+      expect(subject['objects_ssim']).to eq ['123', '456']
+    end
+  end
+end

--- a/spec/hydra/pcdm/services/collection/add_collection_spec.rb
+++ b/spec/hydra/pcdm/services/collection/add_collection_spec.rb
@@ -53,13 +53,6 @@ describe Hydra::PCDM::AddCollectionToCollection do
           Hydra::PCDM::AddCollectionToCollection.call( subject, collection3 )
           expect( Hydra::PCDM::GetCollectionsFromCollection.call( subject ) ).to eq [collection1,collection2,collection3]
         end
-
-        it 'should solrize member ids' do
-          expect(subject.to_solr["objects_ssim"]).to include(object1.id,object2.id)
-          expect(subject.to_solr["objects_ssim"]).not_to include(collection2.id,collection1.id)
-          expect(subject.to_solr["collections_ssim"]).to include(collection2.id,collection1.id)
-          expect(subject.to_solr["collections_ssim"]).not_to include(object1.id,object2.id)
-        end
       end
 
       describe "adding collections that are ancestors" do

--- a/spec/hydra/pcdm/services/collection/add_object_spec.rb
+++ b/spec/hydra/pcdm/services/collection/add_object_spec.rb
@@ -43,13 +43,6 @@ describe Hydra::PCDM::AddObjectToCollection do
           Hydra::PCDM::AddObjectToCollection.call( subject, object3 )
           expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [object1,object2,object3]
         end
-
-        it 'should solrize member ids' do
-          expect(subject.to_solr["objects_ssim"]).to include(object1.id,object2.id)
-          expect(subject.to_solr["objects_ssim"]).not_to include(collection2.id,collection1.id)
-          expect(subject.to_solr["collections_ssim"]).to include(collection2.id,collection1.id)
-          expect(subject.to_solr["collections_ssim"]).not_to include(object1.id,object2.id)
-        end
       end
 
       describe 'aggregates objects that implement Hydra::PCDM' do

--- a/spec/hydra/pcdm/services/collection/add_related_object_spec.rb
+++ b/spec/hydra/pcdm/services/collection/add_related_object_spec.rb
@@ -45,13 +45,6 @@ describe Hydra::PCDM::AddRelatedObjectToCollection do
           expect( related_objects.include? object4 ).to be true
           expect( related_objects.size ).to eq 2
         end
-
-        it 'should solrize member ids' do
-          expect(subject.to_solr["objects_ssim"]).to include(object1.id,object2.id)
-          expect(subject.to_solr["objects_ssim"]).not_to include(collection2.id,collection1.id,object3.id,object4.id)
-          expect(subject.to_solr["collections_ssim"]).to include(collection2.id,collection1.id)
-          expect(subject.to_solr["collections_ssim"]).not_to include(object1.id,object2.id,object3.id,object4.id)
-        end
       end
     end
 

--- a/spec/hydra/pcdm/services/object/add_object_spec.rb
+++ b/spec/hydra/pcdm/services/object/add_object_spec.rb
@@ -55,13 +55,6 @@ describe Hydra::PCDM::AddObjectToObject do
           Hydra::PCDM::AddObjectToObject.call( subject, object3 )
           expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [object1,object2,object3]
         end
-
-        it 'should solrize member ids' do
-          expect(subject.to_solr["objects_ssim"]).to include(object1.id,object2.id)
-          # expect(subject.to_solr["objects_ssim"]).not_to include(file1.id,file21.id)
-          # expect(subject.to_solr["files_ssim"]).not_to include(file1.id,file2.id)
-          # expect(subject.to_solr["files_ssim"]).to include(object1.id,object2.id)
-        end
       end
 
       describe 'adding objects that are ancestors' do

--- a/spec/hydra/pcdm/services/object/add_related_object_spec.rb
+++ b/spec/hydra/pcdm/services/object/add_related_object_spec.rb
@@ -45,14 +45,6 @@ describe Hydra::PCDM::AddRelatedObjectToObject do
           expect( related_objects.include? object3 ).to be true
           expect( related_objects.size ).to eq 2
         end
-
-        it 'should solrize member ids' do
-          expect(subject.to_solr["objects_ssim"]).to include(object1.id)
-          expect(subject.to_solr["objects_ssim"]).not_to include(object2.id,object3.id)
-          # expect(subject.to_solr["objects_ssim"]).not_to include(file1.id,file2.id)
-          # expect(subject.to_solr["files_ssim"]).not_to include(file1.id,file2.id)
-          # expect(subject.to_solr["files_ssim"]).to include(object1.id,object2.id)
-        end
       end
     end
 


### PR DESCRIPTION
Collection#collections used to return collections that contained this
object (parent collections, see
https://github.com/projecthydra/hydra-collections/blob/master/lib/hydra/collections/collectible.rb#L10
) but now collections returns child collections.  This renaming hopes to
reverse the incompatible naming change.