### PR TITLE
Add content to mock File in object spec.

### DIFF
--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -91,6 +91,8 @@ describe Hydra::PCDM::Object do
     let(:pcdm_thumbnail_uri)  { ::RDF::URI("http://pcdm.org/use#ThumbnailImage") }
 
     before do
+      # Need to add content so that content_changed? returns true.
+      file.content="demo content"
       object.files = [file]
       object.save
     end


### PR DESCRIPTION
The call to `content_changed?` in the call to `save` fails to persist an ActiveFedora File if the content of the File is nil.  Adding dummy contents to to the File in the tests allows to it to be persisted to fedora, and thus alleviates the 404 error that would have been returned on refresh.