### PR TITLE
fix ancestor? fails when ids are nil by checking objects instead

### DIFF
--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -53,20 +53,19 @@ module Hydra::PCDM
 
     def collection_ancestor? collections
       collections.each do |check|
-        return true if check.id == self.id
         return true if ancestor?(check)
       end
       false
     end
 
     def ancestor? collection
-      return true if collection.id == self.id
+      return true if collection == self
       return false if collection.child_collections.empty?
       current_collections = collection.child_collections
       next_batch = []
       while !current_collections.empty? do
         current_collections.each do |c|
-          return true if c.id == self.id
+          return true if c == self
           next_batch += c.child_collections
         end
         current_collections = next_batch

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -59,20 +59,19 @@ module Hydra::PCDM
 
     def object_ancestor? objects
       objects.each do |check|
-        return true if check.id == self.id
         return true if ancestor?(check)
       end
       false
     end
 
     def ancestor? object
-      return true if object.id == self.id
+      return true if object == self
       return false if object.objects.empty?
       current_objects = object.objects
       next_batch = []
       while !current_objects.empty? do
         current_objects.each do |c|
-          return true if c.id == self.id
+          return true if c == self
           next_batch += c.objects
         end
         current_objects = next_batch


### PR DESCRIPTION
Fix by checking objects instead of ids.