### PR TITLE
optimize collection/add_object_spec object/add_object_spec

### DIFF
--- a/spec/hydra/pcdm/services/collection/add_object_spec.rb
+++ b/spec/hydra/pcdm/services/collection/add_object_spec.rb
@@ -2,44 +2,29 @@ require 'spec_helper'
 
 describe Hydra::PCDM::AddObjectToCollection do
 
-  let(:subject) { Hydra::PCDM::Collection.create }
+  let(:subject) { Hydra::PCDM::Collection.new }
 
   describe '#call' do
     context 'with acceptable objects' do
-      let(:object1)     { Hydra::PCDM::Object.create }
-      let(:object2)     { Hydra::PCDM::Object.create }
-      let(:object3)     { Hydra::PCDM::Object.create }
-      let(:collection1) { Hydra::PCDM::Collection.create }
-      let(:collection2) { Hydra::PCDM::Collection.create }
+      let(:object1)     { Hydra::PCDM::Object.new }
+      let(:object2)     { Hydra::PCDM::Object.new }
+      let(:object3)     { Hydra::PCDM::Object.new }
+      let(:collection1) { Hydra::PCDM::Collection.new }
+      let(:collection2) { Hydra::PCDM::Collection.new }
 
-      it 'should add an object to empty collection' do
-        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )
-        expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [object1]
-      end
-
-      it 'should add an object to collection with objects' do
-        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )
-        Hydra::PCDM::AddObjectToCollection.call( subject, object2 )
-        expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [object1,object2]
-      end
-
-      it 'should allow objects to repeat' do
-        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )
-        Hydra::PCDM::AddObjectToCollection.call( subject, object2 )
-        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )
+      it 'should add objects, sub-collections, and repeating collections' do
+        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )      # first add
+        Hydra::PCDM::AddObjectToCollection.call( subject, object2 )      # second add to same collection
+        Hydra::PCDM::AddObjectToCollection.call( subject, object1 )      # repeat an object
         expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [object1,object2,object1]
       end
 
       context 'with collections and objects' do
-        before do
-          Hydra::PCDM::AddCollectionToCollection.call( subject, collection1 )
-          Hydra::PCDM::AddCollectionToCollection.call( subject, collection2 )
+        it 'should add an object to collection with collections and objects' do
           Hydra::PCDM::AddObjectToCollection.call( subject, object1 )
           Hydra::PCDM::AddObjectToCollection.call( subject, object2 )
-          subject.save
-        end
-
-        it 'should add an object to collection with collections and objects' do
+          Hydra::PCDM::AddCollectionToCollection.call( subject, collection1 )
+          Hydra::PCDM::AddCollectionToCollection.call( subject, collection2 )
           Hydra::PCDM::AddObjectToCollection.call( subject, object3 )
           expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [object1,object2,object3]
         end
@@ -52,11 +37,10 @@ describe Hydra::PCDM::AddObjectToCollection do
           end
         end
         after { Object.send(:remove_const, :Ahbject) }
-        let(:ahbject1) { Ahbject.create }
+        let(:ahbject1) { Ahbject.new }
 
         it 'should accept implementing object as a child' do
           Hydra::PCDM::AddObjectToCollection.call( subject, ahbject1 )
-          subject.save
           expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [ahbject1]
         end
 
@@ -68,64 +52,64 @@ describe Hydra::PCDM::AddObjectToCollection do
           end
         end
         after { Object.send(:remove_const, :Awbject) }
-        let(:awbject1) { Awbject.create }
+        let(:awbject1) { Awbject.new }
 
         it 'should accept extending object as a child' do
           Hydra::PCDM::AddObjectToCollection.call( subject, awbject1 )
-          subject.save
           expect( Hydra::PCDM::GetObjectsFromCollection.call( subject ) ).to eq [awbject1]
         end
       end
     end
 
-    context 'with unacceptable objects' do
-      let(:collection1) { Hydra::PCDM::Collection.create }
-      let(:file1) { Hydra::PCDM::File.new }
-      let(:non_PCDM_object) { "I'm not a PCDM object" }
-      let(:af_base_object)  { ActiveFedora::Base.create }
-
-      let(:error_message) { 'child_object must be a pcdm object' }
-
-      it 'should NOT aggregate Hydra::PCDM::Collection in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @collection101   = Hydra::PCDM::Collection.new
+        @collection102   = Hydra::PCDM::Collection.new
+        @object101       = Hydra::PCDM::Object.new
+        @object102       = Hydra::PCDM::Object.new
+        @file101         = Hydra::PCDM::File.new
+        @non_PCDM_object = "I'm not a PCDM object"
+        @af_base_object  = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( subject, file1 ) }.to raise_error(ArgumentError,error_message)
+      context 'with unacceptable objects' do
+        let(:error_message) { 'child_object must be a pcdm object' }
+
+        it 'should NOT aggregate Hydra::PCDM::Collection in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @collection101, @collection102 ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @collection101, @file101 ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @collection101, @non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate AF::Base objects in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @collection101, @af_base_object ) }.to raise_error(ArgumentError,error_message)
+        end
       end
 
-      it 'should NOT aggregate non-PCDM objects in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'with unacceptable parent collection' do
+        let(:error_message) { 'parent_collection must be a pcdm collection' }
 
-      it 'should NOT aggregate AF::Base objects in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
-      end
-    end
+        it 'should NOT accept Hydra::PCDM::Objects as parent collection' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @object101, @object102 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-    context 'with unacceptable parent collection' do
-      let(:collection2)      { Hydra::PCDM::Collection.create }
-      let(:object1)          { Hydra::PCDM::Object.create }
-      let(:file1)            { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.create }
+        it 'should NOT accept Hydra::PCDM::Files as parent collection' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @file101, @object102 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-      let(:error_message) { 'parent_collection must be a pcdm collection' }
+        it 'should NOT accept non-PCDM objects as parent collection' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @non_PCDM_object, @object102 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-      it 'should NOT accept Hydra::PCDM::Objects as parent collection' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( object1, collection2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept Hydra::PCDM::Files as parent collection' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( file1, collection2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept non-PCDM objects as parent collection' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( non_PCDM_object, collection2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept AF::Base objects as parent collection' do
-        expect{ Hydra::PCDM::AddObjectToCollection.call( af_base_object, collection2 ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT accept AF::Base objects as parent collection' do
+          expect{ Hydra::PCDM::AddObjectToCollection.call( @af_base_object, @object102 ) }.to raise_error(ArgumentError,error_message)
+        end
       end
     end
   end

--- a/spec/hydra/pcdm/services/object/add_object_spec.rb
+++ b/spec/hydra/pcdm/services/object/add_object_spec.rb
@@ -2,59 +2,23 @@ require 'spec_helper'
 
 describe Hydra::PCDM::AddObjectToObject do
 
-  let(:subject) { Hydra::PCDM::Object.create }
+  let(:subject) { Hydra::PCDM::Object.new }
 
   describe '#call' do
     context 'with acceptable objects' do
-      let(:object1) { Hydra::PCDM::Object.create }
-      let(:object2) { Hydra::PCDM::Object.create }
-      let(:object3) { Hydra::PCDM::Object.create }
-      let(:object4) { Hydra::PCDM::Object.create }
-      let(:object5) { Hydra::PCDM::Object.create }
+      let(:object1) { Hydra::PCDM::Object.new }
+      let(:object2) { Hydra::PCDM::Object.new }
+      let(:object3) { Hydra::PCDM::Object.new }
+      let(:object4) { Hydra::PCDM::Object.new }
+      let(:object5) { Hydra::PCDM::Object.new }
 
-      it 'should add an object to empty object' do
-        Hydra::PCDM::AddObjectToObject.call( subject, object1 )
-        expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [object1]
-      end
-
-      it 'should add an object to an object with objects' do
-        Hydra::PCDM::AddObjectToObject.call( subject, object1 )
-        Hydra::PCDM::AddObjectToObject.call( subject, object2 )
-        expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [object1,object2]
-      end
-
-      it 'should allow objects to repeat' do
-        Hydra::PCDM::AddObjectToObject.call( subject, object1 )
-        Hydra::PCDM::AddObjectToObject.call( subject, object2 )
-        Hydra::PCDM::AddObjectToObject.call( subject, object1 )
+      it 'should add objects, sub-objects, and repeating objects' do
+        Hydra::PCDM::AddObjectToObject.call( subject, object1 )      # first add
+        Hydra::PCDM::AddObjectToObject.call( subject, object2 )      # second add to same object
+        Hydra::PCDM::AddObjectToObject.call( subject, object1 )      # repeat an object
+        Hydra::PCDM::AddObjectToObject.call( object1, object3 )  # add sub-object
         expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [object1,object2,object1]
-      end
-
-      it 'should aggregate objects in a sub-object of a object' do
-        Hydra::PCDM::AddObjectToObject.call( subject, object1 )
-        object1.save
-        Hydra::PCDM::AddObjectToObject.call( object1, object2 )
-        object2.save
-        expect(subject.objects).to eq [object1]
-        expect(object1.objects).to eq [object2]
-      end
-
-      context 'with files and objects' do
-        let(:file1) { subject.files.build }
-        let(:file2) { subject.files.build }
-
-        before do
-          file1.content = "I'm a file"
-          file2.content = "I am too"
-          Hydra::PCDM::AddObjectToObject.call( subject, object1 )
-          Hydra::PCDM::AddObjectToObject.call( subject, object2 )
-          subject.save!
-        end
-
-        it 'should add an object to an object with files and objects' do
-          Hydra::PCDM::AddObjectToObject.call( subject, object3 )
-          expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [object1,object2,object3]
-        end
+        expect( Hydra::PCDM::GetObjectsFromObject.call( object1 ) ).to eq [object3]
       end
 
       describe 'adding objects that are ancestors' do
@@ -68,7 +32,6 @@ describe Hydra::PCDM::AddObjectToObject do
 
         before do
           Hydra::PCDM::AddObjectToObject.call( object1, object2 )
-          object1.save
         end
 
         it 'raises and error' do
@@ -78,7 +41,6 @@ describe Hydra::PCDM::AddObjectToObject do
         context 'with more ancestors' do
           before do
             Hydra::PCDM::AddObjectToObject.call( object2, object3 )
-            object2.save
           end
 
           it 'raises an error' do
@@ -89,7 +51,6 @@ describe Hydra::PCDM::AddObjectToObject do
             before do
               Hydra::PCDM::AddObjectToObject.call( object3, object4 )
               Hydra::PCDM::AddObjectToObject.call( object3, object5 )
-              object3.save
             end
 
             it 'raises errors' do
@@ -107,11 +68,10 @@ describe Hydra::PCDM::AddObjectToObject do
           end
         end
         after { Object.send(:remove_const, :DummyIncObject) }
-        let(:iobject1) { DummyIncObject.create }
+        let(:iobject1) { DummyIncObject.new }
 
         it 'should accept implementing object as a child' do
           Hydra::PCDM::AddObjectToObject.call( subject, iobject1 )
-          subject.save
           expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [iobject1]
         end
       end
@@ -122,64 +82,62 @@ describe Hydra::PCDM::AddObjectToObject do
           end
         end
         after { Object.send(:remove_const, :DummyExtObject) }
-        let(:eobject1) { DummyExtObject.create }
+        let(:eobject1) { DummyExtObject.new }
 
         it 'should accept extending object as a child' do
           Hydra::PCDM::AddObjectToObject.call( subject, eobject1 )
-          subject.save
           expect( Hydra::PCDM::GetObjectsFromObject.call( subject ) ).to eq [eobject1]
         end
       end
     end
 
-    context 'with unacceptable objects' do
-      let(:collection1) { Hydra::PCDM::Collection.create }
-      let(:file1) { Hydra::PCDM::File.new }
-      let(:non_PCDM_object) { "I'm not a PCDM object" }
-      let(:af_base_object)  { ActiveFedora::Base.create }
-
-      let(:error_message) { 'child_object must be a pcdm object' }
-
-      it 'should NOT aggregate Hydra::PCDM::Collection in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( subject, collection1 ) }.to raise_error(ArgumentError,error_message)
+    context 'with unacceptable inputs' do
+      before(:all) do
+        @collection101   = Hydra::PCDM::Collection.new
+        @object101       = Hydra::PCDM::Object.new
+        @file101         = Hydra::PCDM::File.new
+        @non_PCDM_object = "I'm not a PCDM object"
+        @af_base_object  = ActiveFedora::Base.new
       end
 
-      it 'should NOT aggregate Hydra::PCDM::Files in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( subject, file1 ) }.to raise_error(ArgumentError,error_message)
+      context 'with unacceptable objects' do
+        let(:error_message) { 'child_object must be a pcdm object' }
+
+        it 'should NOT aggregate Hydra::PCDM::Collection in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @object101, @collection101 ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate Hydra::PCDM::Files in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @object101, @file1 ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate non-PCDM objects in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @object101, @non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
+        end
+
+        it 'should NOT aggregate AF::Base objects in objects aggregation' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @object101, @af_base_object ) }.to raise_error(ArgumentError,error_message)
+        end
       end
 
-      it 'should NOT aggregate non-PCDM objects in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( subject, non_PCDM_object ) }.to raise_error(ArgumentError,error_message)
-      end
+      context 'with unacceptable parent object' do
+        let(:error_message) { 'parent_object must be a pcdm object' }
 
-      it 'should NOT aggregate AF::Base objects in objects aggregation' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( subject, af_base_object ) }.to raise_error(ArgumentError,error_message)
-      end
-    end
+        it 'should NOT accept Hydra::PCDM::Collections as parent object' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @collection101, @object101 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-    context 'with unacceptable parent object' do
-      let(:collection1)      { Hydra::PCDM::Collection.create }
-      let(:object2)          { Hydra::PCDM::Object.create }
-      let(:file1)            { Hydra::PCDM::File.new }
-      let(:non_PCDM_object)  { "I'm not a PCDM object" }
-      let(:af_base_object)   { ActiveFedora::Base.create }
+        it 'should NOT accept Hydra::PCDM::Files as parent object' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @file1, @object101 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-      let(:error_message) { 'parent_object must be a pcdm object' }
+        it 'should NOT accept non-PCDM objects as parent object' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @non_PCDM_object, @object101 ) }.to raise_error(ArgumentError,error_message)
+        end
 
-      it 'should NOT accept Hydra::PCDM::Collections as parent object' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( collection1, object2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept Hydra::PCDM::Files as parent object' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( file1, object2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept non-PCDM objects as parent object' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( non_PCDM_object, object2 ) }.to raise_error(ArgumentError,error_message)
-      end
-
-      it 'should NOT accept AF::Base objects as parent object' do
-        expect{ Hydra::PCDM::AddObjectToObject.call( af_base_object, object2 ) }.to raise_error(ArgumentError,error_message)
+        it 'should NOT accept AF::Base objects as parent object' do
+          expect{ Hydra::PCDM::AddObjectToObject.call( @af_base_object, @object101 ) }.to raise_error(ArgumentError,error_message)
+        end
       end
     end
   end


### PR DESCRIPTION
changes to tests to improve execution time

* collapse first 4 tests into one that covers several use cases while avoiding duplicate setups
* for validation tests, create objects only once
* do not save unless absolutely necessary
* use new instead of create (effectively working with objects in memory as they are not saved to Fedora)

Impact:

    before - 15s
    after - 0.2s

This is almost exclusively accounted for by the use of new instead of create.