### PR TITLE
rework API for parent/child methods PLUS includes full tests for PR 126

### DIFF
--- a/lib/hydra/pcdm/collection_indexer.rb
+++ b/lib/hydra/pcdm/collection_indexer.rb
@@ -3,7 +3,7 @@ module Hydra::PCDM
 
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc["members_ssim"]        = object.member_ids
+        solr_doc["members_ssim"]           = object.member_ids
         solr_doc["child_collections_ssim"] = object.child_collections.map { |o| o.id }
       end
     end

--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -44,20 +44,28 @@ module Hydra::PCDM
     def child_collections= collections
       raise ArgumentError, "each collection must be a pcdm collection" unless collections.all? { |c| Hydra::PCDM.collection? c }
       raise ArgumentError, "a collection can't be an ancestor of itself" if collection_ancestor?(collections)
-      self.members = objects + collections
+      self.members = child_objects + collections
     end
 
     def child_collections
       members.to_a.select { |m| Hydra::PCDM.collection? m }
     end
 
-    def objects= objects
+    def child_objects= objects
       raise ArgumentError, "each object must be a pcdm object" unless objects.all? { |o| Hydra::PCDM.object? o }
       self.members = child_collections + objects
     end
 
-    def objects
+    def child_objects
       members.to_a.select { |m| Hydra::PCDM.object? m }
+    end
+
+    def parents
+      aggregated_by
+    end
+
+    def parent_collections
+      aggregated_by.select { |parent| parent.class.included_modules.include?(Hydra::PCDM::CollectionBehavior) }
     end
 
     def collection_ancestor? collections

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -45,12 +45,6 @@ module Hydra::PCDM
       end
     end
 
-    def objects= objects
-      raise ArgumentError, "each object must be a pcdm object" unless objects.all? { |o| Hydra::PCDM.object? o }
-      raise ArgumentError, "an object can't be an ancestor of itself" if object_ancestor?(objects)
-      self.members = objects
-    end
-
     # @return [Boolean] whether this instance is a PCDM Object.
     def pcdm_object?
       true
@@ -61,7 +55,13 @@ module Hydra::PCDM
       false
     end
 
-    def objects
+    def child_objects= objects
+      raise ArgumentError, "each object must be a pcdm object" unless objects.all? { |o| Hydra::PCDM.object? o }
+      raise ArgumentError, "an object can't be an ancestor of itself" if object_ancestor?(objects)
+      self.members = objects
+    end
+
+    def child_objects
       members.to_a.select { |m| Hydra::PCDM.object? m }
     end
 
@@ -86,13 +86,13 @@ module Hydra::PCDM
 
     def ancestor? object
       return true if object == self
-      return false if object.objects.empty?
-      current_objects = object.objects
+      return false if object.child_objects.empty?
+      current_objects = object.child_objects
       next_batch = []
       while !current_objects.empty? do
         current_objects.each do |c|
           return true if c == self
-          next_batch += c.objects
+          next_batch += c.child_objects
         end
         current_objects = next_batch
       end

--- a/lib/hydra/pcdm/object_indexer.rb
+++ b/lib/hydra/pcdm/object_indexer.rb
@@ -2,7 +2,7 @@ module Hydra::PCDM
   class ObjectIndexer < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc["objects_ssim"]     = object.objects.map { |o| o.id }
+        solr_doc["child_objects_ssim"]     = object.child_objects.map { |o| o.id }
       end
     end
 

--- a/lib/hydra/pcdm/services/collection/get_objects.rb
+++ b/lib/hydra/pcdm/services/collection/get_objects.rb
@@ -11,7 +11,7 @@ module Hydra::PCDM
     def self.call( parent_collection )
       raise ArgumentError, "parent_collection must be a pcdm collection" unless Hydra::PCDM.collection? parent_collection
 
-      parent_collection.objects
+      parent_collection.child_objects
     end
 
   end

--- a/lib/hydra/pcdm/services/object/get_objects.rb
+++ b/lib/hydra/pcdm/services/object/get_objects.rb
@@ -11,7 +11,7 @@ module Hydra::PCDM
     def self.call( parent_object )
       raise ArgumentError, "parent_object must be a pcdm object" unless Hydra::PCDM.object? parent_object
 
-      parent_object.objects
+      parent_object.child_objects
     end
 
   end

--- a/spec/hydra/pcdm/collection_indexer_spec.rb
+++ b/spec/hydra/pcdm/collection_indexer_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
 describe Hydra::PCDM::CollectionIndexer do
-  let(:collection) { Hydra::PCDM::Collection.new }
+  let(:collection)         { Hydra::PCDM::Collection.new }
   let(:child_collections1) { Hydra::PCDM::Collection.new(id: '123') }
   let(:child_collections2) { Hydra::PCDM::Collection.new(id: '456') }
-  let(:object1) { Hydra::PCDM::Object.new(id: '789') }
-  let(:indexer) { described_class.new(collection) }
+  let(:child_object1)      { Hydra::PCDM::Object.new(id: '789') }
+  let(:indexer)            { described_class.new(collection) }
 
   before do
     allow(collection).to receive(:child_collections).and_return([child_collections1, child_collections2])
-    allow(collection).to receive(:objects).and_return([object1])
+    allow(collection).to receive(:child_objects).and_return([child_object1])
     allow(collection).to receive(:member_ids).and_return(['123', '456', '789'])
   end
 
@@ -18,7 +18,7 @@ describe Hydra::PCDM::CollectionIndexer do
 
     it "has fields" do
       expect(subject['child_collections_ssim']).to eq ['123', '456']
-      expect(subject['objects_ssim']).to eq ['789']
+      expect(subject['child_objects_ssim']).to eq ['789']
       expect(subject['members_ssim']).to eq ['123', '456', '789']
     end
   end

--- a/spec/hydra/pcdm/object_indexer_spec.rb
+++ b/spec/hydra/pcdm/object_indexer_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 
 describe Hydra::PCDM::ObjectIndexer do
-  let(:object) { Hydra::PCDM::Object.new }
-  let(:subobject1) { Hydra::PCDM::Object.new(id: '123') }
-  let(:subobject2) { Hydra::PCDM::Object.new(id: '456') }
-  let(:indexer) { described_class.new(object) }
+  let(:object)        { Hydra::PCDM::Object.new }
+  let(:child_object1) { Hydra::PCDM::Object.new(id: '123') }
+  let(:child_object2) { Hydra::PCDM::Object.new(id: '456') }
+  let(:indexer)       { described_class.new(object) }
 
   before do
-    allow(object).to receive(:objects).and_return([subobject1, subobject2])
+    allow(object).to receive(:child_objects).and_return([child_object1, child_object2])
   end
 
   describe "#generate_solr_document" do
     subject { indexer.generate_solr_document }
 
     it "has fields" do
-      expect(subject['objects_ssim']).to eq ['123', '456']
+      expect(subject['child_objects_ssim']).to eq ['123', '456']
     end
   end
 end

--- a/spec/hydra/pcdm/services/object/get_objects_spec.rb
+++ b/spec/hydra/pcdm/services/object/get_objects_spec.rb
@@ -20,7 +20,7 @@ describe Hydra::PCDM::GetObjectsFromObject do
         subject.save
         file1.content = "I'm a file"
         file2.content = "I am too"
-        subject.objects += [object1, object2]
+        subject.child_objects += [object1, object2]
       end
 
       it 'should only return objects' do

--- a/spec/hydra/pcdm/services/object/remove_object_spec.rb
+++ b/spec/hydra/pcdm/services/object/remove_object_spec.rb
@@ -13,7 +13,7 @@ describe Hydra::PCDM::RemoveObjectFromObject do
   describe '#call' do
     context 'when it is the only object' do
       before do
-        subject.objects += [object1]
+        subject.child_objects += [object1]
         expect( Hydra::PCDM::GetObjectsFromObject.call( subject )).to eq [object1]
       end
 
@@ -25,7 +25,7 @@ describe Hydra::PCDM::RemoveObjectFromObject do
 
     context 'when multiple objects' do
       before do
-        subject.objects += [object1, object2, object3, object4, object5]
+        subject.child_objects += [object1, object2, object3, object4, object5]
         expect( Hydra::PCDM::GetObjectsFromObject.call( subject )).to eq [object1,object2,object3,object4,object5]
       end
 
@@ -55,7 +55,7 @@ describe Hydra::PCDM::RemoveObjectFromObject do
 
     context 'when object repeats' do
       before do
-        subject.objects += [object1, object2, object3, object2, object4, object2, object5]
+        subject.child_objects += [object1, object2, object3, object2, object4, object2, object5]
         expect(Hydra::PCDM::GetObjectsFromObject.call( subject )).to eq [object1,object2,object3,object2,object4,object2,object5]
       end
 
@@ -99,12 +99,12 @@ describe Hydra::PCDM::RemoveObjectFromObject do
       end
 
       it 'and multiple objects in object should return nil when changes are in memory' do
-        subject.objects += [object1, object2, object4, object5]
+        subject.child_objects += [object1, object2, object4, object5]
         expect( Hydra::PCDM::RemoveObjectFromObject.call( subject, object3 )).to be nil
       end
 
       it 'should return nil when changes are saved' do
-        subject.objects += [object1, object2, object4, object5]
+        subject.child_objects += [object1, object2, object4, object5]
         subject.save
         expect( Hydra::PCDM::RemoveObjectFromObject.call( subject.reload, object3 ) ).to be nil
       end


### PR DESCRIPTION
Reworks API to consistently use child_ and parent_ prefixes for object and collection getter/setter methods.

Collection methods names:
* parents
* parent_collections
* child_collections=
* child_colldctions
* child_objects=
* child_objects

Object methods names:
* parents
* parent_collections
* parent_objects
* child_objects=
* child_objects

Includes full set of tests from branch objects_validations_full_tests with parent/child method name changes.

Tests for PR https://github.com/projecthydra-labs/hydra-pcdm/pull/126/files

Identifies the following systematic failures:
* << fails to add object
* << does not validate
* objects= uses a different process from objects<<, object+=, members=, members<<, members+=
* object= a produce difference validation error message than the other setters (due to using different processes)
* error message states that the argument for child objects can be either a pcdm object or collection.  Message should state only pcdm object should be allowed.