### PR TITLE
Remove child_object_ids method.

### DIFF
--- a/lib/hydra/pcdm/models/concerns/child_objects.rb
+++ b/lib/hydra/pcdm/models/concerns/child_objects.rb
@@ -1,9 +1,5 @@
 module Hydra::PCDM
   module ChildObjects
-    def child_object_ids
-      child_objects.map(&:id)
-    end
-
     def objects= objects
       warn "[DEPRECATION] `objects=` is deprecated.  Please use `child_objects=` instead.  This has a target date for removal of 07-31-2015"
       self.child_objects= objects


### PR DESCRIPTION
This is no longer needed because it's implemented by the filter associations.