### PR TITLE
New ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,7 @@ group :development, :test do
   gem 'pry-byebug' unless ENV['CI']
 end
 
+gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation'
+
 # Specify your gem's dependencies in hydra-pcdm.gemspec
 gemspec

--- a/lib/hydra/pcdm/collection_indexer.rb
+++ b/lib/hydra/pcdm/collection_indexer.rb
@@ -3,7 +3,7 @@ module Hydra::PCDM
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc['member_ids_ssim'] = object.member_ids
-        solr_doc['collection_ids_ssim'] = object.collection_ids
+        solr_doc['collection_ids_ssim'] = object.ordered_collection_ids
       end
     end
   end

--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -28,7 +28,7 @@ module Hydra::PCDM
     end
 
     def collections
-      members.select(&:pcdm_collection?)
+      ordered_members.to_a.select(&:pcdm_collection?)
     end
 
     def collection_ids

--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -28,11 +28,19 @@ module Hydra::PCDM
     end
 
     def collections
-      ordered_members.to_a.select(&:pcdm_collection?)
+      members.select(&:pcdm_collection?)
     end
 
     def collection_ids
-      collections.map(&:id)
+      members.select(&:pcdm_collection?).map(&:id)
+    end
+
+    def ordered_collections
+      ordered_members.to_a.select(&:pcdm_collection?)
+    end
+
+    def ordered_collection_ids
+      ordered_collections.map(&:id)
     end
 
     def pcdm_object?
@@ -45,12 +53,12 @@ module Hydra::PCDM
 
     def child_collections
       warn '[DEPRECATION] `child_collections` is deprecated in Hydra::PCDM.  Please use `collections` instead.  This has a target date for removal of 10-31-2015'
-      collections
+      ordered_collections
     end
 
     def child_collection_ids
       warn '[DEPRECATION] `child_collection_ids` is deprecated in Hydra::PCDM.  Please use `collection_ids` instead.  This has a target date for removal of 10-31-2015'
-      collection_ids
+      ordered_collection_ids
     end
   end
 end

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -40,7 +40,7 @@ module Hydra::PCDM
     end
 
     def in_objects
-      aggregated_by.select(&:pcdm_object?)
+      ordered_by.select(&:pcdm_object?).to_a
     end
 
     def parent_objects

--- a/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
@@ -3,10 +3,10 @@ module Hydra::PCDM
     extend ActiveSupport::Concern
     included do
       ordered_aggregation :members,
-        has_member_relation: Vocab::PCDMTerms.hasMember,
-        class_name: 'ActiveFedora::Base',
-        type_validator: type_validator,
-        through: :list_source
+                          has_member_relation: Vocab::PCDMTerms.hasMember,
+                          class_name: 'ActiveFedora::Base',
+                          type_validator: type_validator,
+                          through: :list_source
       indirectly_contains :related_objects, has_member_relation: RDF::Vocab::ORE.aggregates,
                                             inserted_content_relation: RDF::Vocab::ORE.proxyFor, class_name: 'ActiveFedora::Base',
                                             through: 'ActiveFedora::Aggregation::Proxy', foreign_key: :target,
@@ -32,7 +32,7 @@ module Hydra::PCDM
     end
 
     def objects
-      members.select(&:pcdm_object?)
+      ordered_members.to_a.select(&:pcdm_object?)
     end
 
     def object_ids
@@ -45,7 +45,7 @@ module Hydra::PCDM
     end
 
     def in_collections
-      ordered_by.select(&:pcdm_collection?)
+      ordered_by.select(&:pcdm_collection?).to_a
     end
 
     def parent_collections

--- a/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
@@ -32,11 +32,19 @@ module Hydra::PCDM
     end
 
     def objects
-      ordered_members.to_a.select(&:pcdm_object?)
+      members.select(&:pcdm_object?)
     end
 
     def object_ids
-      objects.map(&:id)
+      members.select(&:pcdm_object?).map(&:id)
+    end
+
+    def ordered_objects
+      ordered_members.to_a.select(&:pcdm_object?)
+    end
+
+    def ordered_object_ids
+      ordered_objects.map(&:id)
     end
 
     def parents
@@ -72,7 +80,7 @@ module Hydra::PCDM
 
     def child_objects
       warn '[DEPRECATION] `child_objects` is deprecated in Hydra::PCDM.  Please use `objects` instead.  This has a target date for removal of 10-31-2015'
-      objects
+      ordered_objects
     end
 
     def child_object_ids

--- a/lib/hydra/pcdm/object_indexer.rb
+++ b/lib/hydra/pcdm/object_indexer.rb
@@ -2,7 +2,7 @@ module Hydra::PCDM
   class ObjectIndexer < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc['object_ids_ssim'] = object.object_ids
+        solr_doc['object_ids_ssim'] = object.ordered_object_ids
       end
     end
   end

--- a/spec/hydra/pcdm/collection_indexer_spec.rb
+++ b/spec/hydra/pcdm/collection_indexer_spec.rb
@@ -8,7 +8,7 @@ describe Hydra::PCDM::CollectionIndexer do
   let(:indexer) { described_class.new(collection) }
 
   before do
-    allow(collection).to receive(:collection_ids).and_return(collection_ids)
+    allow(collection).to receive(:ordered_collection_ids).and_return(collection_ids)
     allow(collection).to receive(:object_ids).and_return(object_ids)
     allow(collection).to receive(:member_ids).and_return(member_ids)
   end

--- a/spec/hydra/pcdm/collection_indexer_spec.rb
+++ b/spec/hydra/pcdm/collection_indexer_spec.rb
@@ -9,7 +9,7 @@ describe Hydra::PCDM::CollectionIndexer do
 
   before do
     allow(collection).to receive(:ordered_collection_ids).and_return(collection_ids)
-    allow(collection).to receive(:object_ids).and_return(object_ids)
+    allow(collection).to receive(:ordered_object_ids).and_return(object_ids)
     allow(collection).to receive(:member_ids).and_return(member_ids)
   end
 

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -10,8 +10,8 @@ describe Hydra::PCDM::Collection do
   let(:object2) { Hydra::PCDM::Object.new }
   let(:object3) { Hydra::PCDM::Object.new }
 
-  describe "#collections" do
-    it "returns non-ordered collections" do
+  describe '#collections' do
+    it 'returns non-ordered collections' do
       collection1.members += [collection2, collection3]
       collection1.ordered_members << collection4
 
@@ -20,12 +20,31 @@ describe Hydra::PCDM::Collection do
     end
   end
 
-  describe "#collection_ids" do
-    it "returns IDs of non-ordered collections" do
+  describe '#collection_ids' do
+    it 'returns IDs of non-ordered collections' do
       collection1.members += [collection2, collection3]
       collection1.ordered_members << collection4
 
       expect(collection1.collection_ids).to eq [collection2.id, collection3.id, collection4.id]
+    end
+  end
+
+  describe '#objects' do
+    it 'returns non-ordered objects' do
+      collection1.members += [object1, object2]
+      collection1.ordered_members << object3
+
+      expect(collection1.objects).to eq [object1, object2, object3]
+      expect(collection1.ordered_objects).to eq [object3]
+    end
+  end
+
+  describe '#object_ids' do
+    it 'returns IDs of non-ordered objects' do
+      collection1.members += [object1, object2]
+      collection1.ordered_members << object3
+
+      expect(collection1.object_ids).to eq [object1.id, object2.id, object3.id]
     end
   end
 
@@ -40,7 +59,7 @@ describe Hydra::PCDM::Collection do
         subject.ordered_members << collection3
         expect(subject.ordered_members).to eq [collection1, collection2, object1, object2, collection3]
         expect(subject.ordered_collections).to eq [collection1, collection2, collection3]
-        expect(subject.objects).to eq [object1, object2]
+        expect(subject.ordered_objects).to eq [object1, object2]
       end
     end
 
@@ -183,7 +202,7 @@ describe Hydra::PCDM::Collection do
         subject.ordered_members << object2
         subject.ordered_member_proxies.delete_at(0)
         expect(subject.ordered_collections).to eq []
-        expect(subject.objects).to eq [object1, object2]
+        expect(subject.ordered_objects).to eq [object1, object2]
       end
     end
 
@@ -252,7 +271,7 @@ describe Hydra::PCDM::Collection do
           subject.ordered_members << collection1
           subject.ordered_members << collection2
           subject.ordered_members << object2
-          expect(subject.objects).to eq [object1, object2]
+          expect(subject.ordered_objects).to eq [object1, object2]
         end
       end
 
@@ -267,7 +286,7 @@ describe Hydra::PCDM::Collection do
 
         it 'accepts implementing object as a child' do
           subject.ordered_members << ahbject1
-          expect(subject.objects).to eq [ahbject1]
+          expect(subject.ordered_objects).to eq [ahbject1]
         end
       end
 
@@ -281,7 +300,7 @@ describe Hydra::PCDM::Collection do
 
         it 'accepts extending object as a child' do
           subject.ordered_members << awbject1
-          expect(subject.objects).to eq [awbject1]
+          expect(subject.ordered_objects).to eq [awbject1]
         end
       end
     end
@@ -390,7 +409,7 @@ describe Hydra::PCDM::Collection do
         expect(subject.related_objects.delete object1).to eq [object1]
         expect(subject.related_objects).to eq []
         expect(subject.ordered_collections).to eq [collection1, collection2]
-        expect(subject.objects).to eq [object3, object2]
+        expect(subject.ordered_objects).to eq [object3, object2]
       end
     end
 
@@ -495,7 +514,7 @@ describe Hydra::PCDM::Collection do
 
     it 'returns empty array when no members' do
       expect(subject.ordered_collections).to eq []
-      expect(subject.objects).to eq []
+      expect(subject.ordered_objects).to eq []
     end
 
     it 'collections should return empty array when only objects are aggregated' do
@@ -507,7 +526,7 @@ describe Hydra::PCDM::Collection do
     it 'objects should return empty array when only collections are aggregated' do
       subject.ordered_members << collection1
       subject.ordered_members << collection2
-      expect(subject.objects).to eq []
+      expect(subject.ordered_objects).to eq []
     end
 
     context 'should only contain members of the correct type' do
@@ -517,7 +536,7 @@ describe Hydra::PCDM::Collection do
         subject.ordered_members << object1
         subject.ordered_members << object2
         expect(subject.ordered_collections).to eq [collection1, collection2]
-        expect(subject.objects).to eq [object1, object2]
+        expect(subject.ordered_objects).to eq [object1, object2]
         expect(subject.ordered_members).to eq [collection1, collection2, object1, object2]
       end
     end

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -14,12 +14,12 @@ describe Hydra::PCDM::Collection do
     describe 'with acceptable inputs' do
       subject { described_class.new }
       it 'adds an object to collection with collections and objects' do
-        subject.members << collection1
-        subject.members << collection2
-        subject.members << object1
-        subject.members << object2
-        subject.members << collection3
-        expect(subject.members).to eq [collection1, collection2, object1, object2, collection3]
+        subject.ordered_members << collection1
+        subject.ordered_members << collection2
+        subject.ordered_members << object1
+        subject.ordered_members << object2
+        subject.ordered_members << collection3
+        expect(subject.ordered_members).to eq [collection1, collection2, object1, object2, collection3]
         expect(subject.collections).to eq [collection1, collection2, collection3]
         expect(subject.objects).to eq [object1, object2]
       end
@@ -27,8 +27,8 @@ describe Hydra::PCDM::Collection do
 
     describe '#in_collection_ids' do
       it 'returns the IDs of the parent' do
-        subject.members << object1
-        subject.members << collection1
+        subject.ordered_members << object1
+        subject.ordered_members << collection1
         subject.save
         expect(object1.in_collection_ids).to eq [subject.id]
         expect(collection1.in_collection_ids).to eq [subject.id]
@@ -45,12 +45,12 @@ describe Hydra::PCDM::Collection do
       let(:kollection1) { Kollection.new }
 
       it 'accepts implementing collection as a child' do
-        subject.members << kollection1
+        subject.ordered_members << kollection1
         expect(subject.collections).to eq [kollection1]
       end
 
       it 'accepts implementing collection as a parent' do
-        kollection1.members << collection1
+        kollection1.ordered_members << collection1
         expect(kollection1.collections).to eq [collection1]
       end
     end
@@ -64,12 +64,12 @@ describe Hydra::PCDM::Collection do
       let(:cullection1) { Cullection.new }
 
       it 'accepts extending collection as a child' do
-        subject.members << cullection1
+        subject.ordered_members << cullection1
         expect(subject.collections).to eq [cullection1]
       end
 
       it 'accepts extending collection as a parent' do
-        cullection1.members << collection1
+        cullection1.ordered_members << collection1
         expect(cullection1.collections).to eq [collection1]
       end
     end
@@ -91,15 +91,15 @@ describe Hydra::PCDM::Collection do
         let(:error_message3) { /ActiveFedora::Base\(#\d+\) expected, got Hydra::PCDM::File\(#[\d]+\)/ }
 
         it 'raises an error when trying to aggregate Hydra::PCDM::Files in members aggregation' do
-          expect { collection1.members << @file101 }.to raise_error(error_type3, error_message3)
+          expect { collection1.ordered_members << @file101 }.to raise_error(error_type3, error_message3)
         end
 
         it 'raises an error when trying to aggregate non-PCDM objects in members aggregation' do
-          expect { collection1.members << @non_pcdm_object }.to raise_error(error_type1, error_message1)
+          expect { collection1.ordered_members << @non_pcdm_object }.to raise_error(error_type1, error_message1)
         end
 
         it 'raises an error when trying to aggregate AF::Base objects in members aggregation' do
-          expect { collection1.members << @af_base_object }.to raise_error(error_type2, error_message2)
+          expect { collection1.ordered_members << @af_base_object }.to raise_error(error_type2, error_message2)
         end
       end
     end
@@ -110,35 +110,35 @@ describe Hydra::PCDM::Collection do
 
       context 'when the source collection is the same' do
         it 'raises an error' do
-          expect { subject.members << subject }.to raise_error(error_type, error_message)
+          expect { subject.ordered_members << subject }.to raise_error(error_type, error_message)
         end
       end
 
       before do
-        subject.members << collection1
+        subject.ordered_members << collection1
       end
 
       it 'raises and error' do
-        expect { collection1.members << subject }.to raise_error(error_type, error_message)
+        expect { collection1.ordered_members << subject }.to raise_error(error_type, error_message)
       end
 
       context 'with more ancestors' do
         before do
-          collection1.members << collection2
+          collection1.ordered_members << collection2
         end
 
         it 'raises an error' do
-          expect { collection2.members << subject }.to raise_error(error_type, error_message)
+          expect { collection2.ordered_members << subject }.to raise_error(error_type, error_message)
         end
 
         context 'with a more complicated example' do
           before do
-            collection2.members << collection3
+            collection2.ordered_members << collection3
           end
 
           it 'raises errors' do
-            expect { collection3.members << subject }.to raise_error(error_type, error_message)
-            expect { collection3.members << collection1 }.to raise_error(error_type, error_message)
+            expect { collection3.ordered_members << subject }.to raise_error(error_type, error_message)
+            expect { collection3.ordered_members << collection1 }.to raise_error(error_type, error_message)
           end
         end
       end
@@ -150,19 +150,19 @@ describe Hydra::PCDM::Collection do
 
     context 'when it is the only collection' do
       before do
-        subject.members << collection1
+        subject.ordered_members << collection1
         expect(subject.collections).to eq [collection1]
       end
 
       it 'removes collection while changes are in memory' do
-        expect(subject.members.delete collection1).to eq [collection1]
+        subject.ordered_member_proxies.delete_at(0)
         expect(subject.collections).to eq []
       end
 
       it 'removes collection only when objects and all changes are in memory' do
-        subject.members << object1
-        subject.members << object2
-        expect(subject.members.delete collection1).to eq [collection1]
+        subject.ordered_members << object1
+        subject.ordered_members << object2
+        subject.ordered_member_proxies.delete_at(0)
         expect(subject.collections).to eq []
         expect(subject.objects).to eq [object1, object2]
       end
@@ -170,31 +170,31 @@ describe Hydra::PCDM::Collection do
 
     context 'when multiple collections' do
       before do
-        subject.members << collection1
-        subject.members << collection2
-        subject.members << collection3
+        subject.ordered_members << collection1
+        subject.ordered_members << collection2
+        subject.ordered_members << collection3
         expect(subject.collections).to eq [collection1, collection2, collection3]
       end
 
       it 'removes first collection when changes are in memory' do
-        expect(subject.members.delete collection1).to eq [collection1]
+        subject.ordered_member_proxies.delete_at(0)
         expect(subject.collections).to eq [collection2, collection3]
       end
 
       it 'removes last collection when changes are in memory' do
-        expect(subject.members.delete collection3).to eq [collection3]
+        subject.ordered_member_proxies.delete_at(2)
         expect(subject.collections).to eq [collection1, collection2]
       end
 
       it 'removes middle collection when changes are in memory' do
-        expect(subject.members.delete collection2).to eq [collection2]
+        subject.ordered_member_proxies.delete_at(1)
         expect(subject.collections).to eq [collection1, collection3]
       end
 
       it 'removes middle collection when changes are saved' do
         expect(subject.collections).to eq [collection1, collection2, collection3]
         subject.save
-        expect(subject.members.delete collection2).to eq [collection2]
+        subject.ordered_member_proxies.delete_at(1)
         expect(subject.collections).to eq [collection1, collection3]
       end
     end
@@ -204,14 +204,14 @@ describe Hydra::PCDM::Collection do
       end
 
       it 'and multiple sub-collections should return empty array when changes are in memory' do
-        subject.members << collection1
-        subject.members << collection3
+        subject.ordered_members << collection1
+        subject.ordered_members << collection3
         expect(subject.members.delete collection2).to eq []
       end
 
       it 'returns empty array when changes are saved' do
-        subject.members << collection1
-        subject.members << collection3
+        subject.ordered_members << collection1
+        subject.ordered_members << collection3
         subject.save
         expect(subject.members.delete collection2).to eq []
       end
@@ -221,18 +221,18 @@ describe Hydra::PCDM::Collection do
   describe 'adding objects' do
     context 'with acceptable inputs' do
       it 'adds objects, sub-collections, and repeating collections' do
-        subject.members << object1      # first add
-        subject.members << object2      # second add to same collection
-        subject.members << object1      # repeat an object
-        expect(subject.members).to eq [object1, object2, object1]
+        subject.ordered_members << object1      # first add
+        subject.ordered_members << object2      # second add to same collection
+        subject.ordered_members << object1      # repeat an object
+        expect(subject.ordered_members).to eq [object1, object2, object1]
       end
 
       context 'with collections and objects' do
         it 'adds an object to collection with collections and objects' do
-          subject.members << object1
-          subject.members << collection1
-          subject.members << collection2
-          subject.members << object2
+          subject.ordered_members << object1
+          subject.ordered_members << collection1
+          subject.ordered_members << collection2
+          subject.ordered_members << object2
           expect(subject.objects).to eq [object1, object2]
         end
       end
@@ -247,7 +247,7 @@ describe Hydra::PCDM::Collection do
         let(:ahbject1) { Ahbject.new }
 
         it 'accepts implementing object as a child' do
-          subject.members << ahbject1
+          subject.ordered_members << ahbject1
           expect(subject.objects).to eq [ahbject1]
         end
       end
@@ -261,7 +261,7 @@ describe Hydra::PCDM::Collection do
         let(:awbject1) { Awbject.new }
 
         it 'accepts extending object as a child' do
-          subject.members << awbject1
+          subject.ordered_members << awbject1
           expect(subject.objects).to eq [awbject1]
         end
       end
@@ -364,10 +364,10 @@ describe Hydra::PCDM::Collection do
       end
 
       it 'removes related object only when objects & collections and all changes are in memory' do
-        subject.members << collection1
-        subject.members << collection2
-        subject.members << object3
-        subject.members << object2
+        subject.ordered_members << collection1
+        subject.ordered_members << collection2
+        subject.ordered_members << object3
+        subject.ordered_members << object2
         expect(subject.related_objects.delete object1).to eq [object1]
         expect(subject.related_objects).to eq []
         expect(subject.collections).to eq [collection1, collection2]
@@ -416,10 +416,10 @@ describe Hydra::PCDM::Collection do
       end
 
       it 'returns empty array when 0 related objects, but has collections and objects and changes in memory' do
-        subject.members << collection1
-        subject.members << collection2
-        subject.members << object1
-        subject.members << object2
+        subject.ordered_members << collection1
+        subject.ordered_members << collection2
+        subject.ordered_members << object1
+        subject.ordered_members << object2
         expect(subject.related_objects.delete object1).to eq []
       end
 
@@ -464,7 +464,7 @@ describe Hydra::PCDM::Collection do
     let(:child1) { described_class.new(id: '1') }
     let(:child2) { described_class.new(id: '2') }
     let(:object) { described_class.new }
-    before { object.members = [child1, child2] }
+    before { object.ordered_members = [child1, child2] }
 
     subject { object.collection_ids }
 
@@ -480,26 +480,26 @@ describe Hydra::PCDM::Collection do
     end
 
     it 'collections should return empty array when only objects are aggregated' do
-      subject.members << object1
-      subject.members << object2
+      subject.ordered_members << object1
+      subject.ordered_members << object2
       expect(subject.collections).to eq []
     end
 
     it 'objects should return empty array when only collections are aggregated' do
-      subject.members << collection1
-      subject.members << collection2
+      subject.ordered_members << collection1
+      subject.ordered_members << collection2
       expect(subject.objects).to eq []
     end
 
     context 'should only contain members of the correct type' do
       it 'returns only collections' do
-        subject.members << collection1
-        subject.members << collection2
-        subject.members << object1
-        subject.members << object2
+        subject.ordered_members << collection1
+        subject.ordered_members << collection2
+        subject.ordered_members << object1
+        subject.ordered_members << object2
         expect(subject.collections).to eq [collection1, collection2]
         expect(subject.objects).to eq [object1, object2]
-        expect(subject.members).to eq [collection1, collection2, object1, object2]
+        expect(subject.ordered_members).to eq [collection1, collection2, object1, object2]
       end
     end
   end
@@ -511,14 +511,10 @@ describe Hydra::PCDM::Collection do
       @collection1 = described_class.new
       @collection2 = described_class.new
       @collection =  described_class.new
-      @collection1.members << @collection
-      @collection2.members << @collection
-      allow(@collection).to receive(:id).and_return('banana')
-      proxies = [
-        build_proxy(container: @collection1),
-        build_proxy(container: @collection2)
-      ]
-      allow(ActiveFedora::Aggregation::Proxy).to receive(:where).with(proxyFor_ssim: @collection.id).and_return(proxies)
+      @collection1.ordered_members << @collection
+      @collection2.ordered_members << @collection
+      @collection1.save
+      @collection2.save
     end
 
     describe 'member_of' do
@@ -535,9 +531,6 @@ describe Hydra::PCDM::Collection do
         expect(subject).to include(@collection1, @collection2)
         expect(subject.count).to eq 2
       end
-    end
-    def build_proxy(container:)
-      instance_double(ActiveFedora::Aggregation::Proxy, container: container)
     end
   end
 
@@ -584,12 +577,12 @@ describe Hydra::PCDM::Collection do
 
   describe 'make sure deprecated methods still work' do
     it 'deprecated methods should pass' do
-      expect(collection1.members = [collection2]).to eq [collection2]
-      expect(collection1.members << collection3).to eq [collection2, collection3]
-      expect(collection1.members += [collection4]).to eq [collection2, collection3, collection4]
-      expect(collection1.members << [object1]).to eq [collection2, collection3, collection4, object1]
-      expect(collection1.members << object2).to eq [collection2, collection3, collection4, object1, object2]
-      expect(collection1.members += [object3]).to eq [collection2, collection3, collection4, object1, object2, object3]
+      expect(collection1.ordered_members = [collection2]).to eq [collection2]
+      expect(collection1.ordered_members << collection3).to eq [collection2, collection3]
+      expect(collection1.ordered_members += [collection4]).to eq [collection2, collection3, collection4]
+      expect(collection1.ordered_members << object1).to eq [collection2, collection3, collection4, object1]
+      expect(collection1.ordered_members << object2).to eq [collection2, collection3, collection4, object1, object2]
+      expect(collection1.ordered_members += [object3]).to eq [collection2, collection3, collection4, object1, object2, object3]
       collection1.save # required until issue AF-Agg-75 is fixed
       expect(collection2.parent_collections).to eq [collection1]
       expect(collection2.parents).to eq [collection1]

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -5,7 +5,10 @@ describe Hydra::PCDM::Object do
     let(:child1) { described_class.new(id: '1') }
     let(:child2) { described_class.new(id: '2') }
     let(:object) { described_class.new }
-    before { object.members = [child1, child2] }
+    before do
+      object.ordered_members << child1
+      object.ordered_members << child2
+    end
 
     subject { object.object_ids }
 
@@ -21,22 +24,22 @@ describe Hydra::PCDM::Object do
       let(:object5) { described_class.new }
 
       it 'add objects' do
-        subject.members = [object1, object2]
-        subject.members << object3
-        subject.members += [object4, object5]
-        expect(subject.members).to eq [object1, object2, object3, object4, object5]
+        subject.ordered_members = [object1, object2]
+        subject.ordered_members << object3
+        subject.ordered_members += [object4, object5]
+        expect(subject.ordered_members).to eq [object1, object2, object3, object4, object5]
       end
 
       it 'allow sub-objects' do
-        subject.members = [object1, object2]
-        object1.members = [object3]
-        expect(subject.members).to eq [object1, object2]
-        expect(object1.members).to eq [object3]
+        subject.ordered_members = [object1, object2]
+        object1.ordered_members = [object3]
+        expect(subject.ordered_members).to eq [object1, object2]
+        expect(object1.ordered_members).to eq [object3]
       end
 
       it 'allow repeating objects' do
-        subject.members = [object1, object2, object1]
-        expect(subject.members).to eq [object1, object2, object1]
+        subject.ordered_members = [object1, object2, object1]
+        expect(subject.ordered_members).to eq [object1, object2, object1]
       end
 
       describe 'adding objects that are ancestors' do
@@ -45,46 +48,46 @@ describe Hydra::PCDM::Object do
 
         context 'when the source object is the same' do
           it 'raises an error' do
-            expect { object1.members = [object1] }.to raise_error(error_type, error_message)
-            expect { object1.members += [object1] }.to raise_error(error_type, error_message)
-            expect { object1.members << [object1] }.to raise_error(error_type, error_message)
+            expect { object1.ordered_members = [object1] }.to raise_error(error_type, error_message)
+            expect { object1.ordered_members += [object1] }.to raise_error(error_type, error_message)
+            expect { object1.ordered_members << [object1] }.to raise_error(error_type, error_message)
           end
         end
 
         before do
-          object1.members = [object2]
+          object1.ordered_members = [object2]
         end
 
         it 'raises an error' do
-          expect { object2.members += [object1] }.to raise_error(error_type, error_message)
-          expect { object2.members << [object1] }.to raise_error(error_type, error_message)
-          expect { object2.members = [object1] }.to raise_error(error_type, error_message)
+          expect { object2.ordered_members += [object1] }.to raise_error(error_type, error_message)
+          expect { object2.ordered_members << [object1] }.to raise_error(error_type, error_message)
+          expect { object2.ordered_members = [object1] }.to raise_error(error_type, error_message)
         end
 
         context 'with more ancestors' do
           before do
-            object2.members = [object3]
+            object2.ordered_members = [object3]
           end
 
           it 'raises an error' do
-            expect { object3.members << [object1] }.to raise_error(error_type, error_message)
-            expect { object3.members = [object1] }.to raise_error(error_type, error_message)
-            expect { object3.members += [object1] }.to raise_error(error_type, error_message)
+            expect { object3.ordered_members << [object1] }.to raise_error(error_type, error_message)
+            expect { object3.ordered_members = [object1] }.to raise_error(error_type, error_message)
+            expect { object3.ordered_members += [object1] }.to raise_error(error_type, error_message)
           end
 
           context 'with a more complicated example' do
             before do
-              object3.members = [object4, object5]
+              object3.ordered_members = [object4, object5]
             end
 
             it 'raises errors' do
-              expect { object4.members = [object1] }.to raise_error(error_type, error_message)
-              expect { object4.members += [object1] }.to raise_error(error_type, error_message)
-              expect { object4.members << [object1] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members = [object1] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members += [object1] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members << [object1] }.to raise_error(error_type, error_message)
 
-              expect { object4.members = [object2] }.to raise_error(error_type, error_message)
-              expect { object4.members += [object2] }.to raise_error(error_type, error_message)
-              expect { object4.members << [object2] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members = [object2] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members += [object2] }.to raise_error(error_type, error_message)
+              expect { object4.ordered_members << [object2] }.to raise_error(error_type, error_message)
             end
           end
         end
@@ -110,26 +113,26 @@ describe Hydra::PCDM::Object do
       let(:error_message3) { /ActiveFedora::Base\(#\d+\) expected, got String\(#[\d]+\)/ }
 
       it 'NOT aggregate Hydra::PCDM::Collection in members aggregation' do
-        expect { @object101.members = [@collection101] }.to raise_error(error_type1, error_message1)
-        expect { @object101.members += [@collection101] }.to raise_error(error_type1, error_message1)
-        expect { @object101.members << @collection101 }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members = [@collection101] }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members += [@collection101] }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members << @collection101 }.to raise_error(error_type1, error_message1)
       end
       it 'NOT aggregate Hydra::PCDM::Files in members aggregation' do
-        expect { @object101.members += [@file1] }.to raise_error(error_type2, error_message2)
-        expect { @object101.members << @file1 }.to raise_error(error_type2, error_message2)
-        expect { @object101.members = [@file1] }.to raise_error(error_type2, error_message2)
+        expect { @object101.ordered_members += [@file1] }.to raise_error(error_type2, error_message2)
+        expect { @object101.ordered_members << @file1 }.to raise_error(error_type2, error_message2)
+        expect { @object101.ordered_members = [@file1] }.to raise_error(error_type2, error_message2)
       end
 
       it 'NOT aggregate non-PCDM objects in members aggregation' do
-        expect { @object101.members << @non_pcdm_object }.to raise_error(error_type3, error_message3)
-        expect { @object101.members = [@non_pcdm_object] }.to raise_error(error_type3, error_message3)
-        expect { @object101.members += [@non_pcdm_object] }.to raise_error(error_type3, error_message3)
+        expect { @object101.ordered_members << @non_pcdm_object }.to raise_error(error_type3, error_message3)
+        expect { @object101.ordered_members = [@non_pcdm_object] }.to raise_error(error_type3, error_message3)
+        expect { @object101.ordered_members += [@non_pcdm_object] }.to raise_error(error_type3, error_message3)
       end
 
       it 'NOT aggregate non-PCDM AF::Base objects in members aggregation' do
-        expect { @object101.members = [@af_base_object] }.to raise_error(error_type1, error_message1)
-        expect { @object101.members += [@af_base_object] }.to raise_error(error_type1, error_message1)
-        expect { @object101.members << @af_base_object }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members = [@af_base_object] }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members += [@af_base_object] }.to raise_error(error_type1, error_message1)
+        expect { @object101.ordered_members << @af_base_object }.to raise_error(error_type1, error_message1)
       end
     end
   end
@@ -142,16 +145,12 @@ describe Hydra::PCDM::Object do
       @collection2 = Hydra::PCDM::Collection.new
       @parent_object = described_class.new
       @object = described_class.new
-      @collection1.members = [@object]
-      @collection2.members = [@object]
-      @parent_object.members = [@object]
-      allow(@object).to receive(:id).and_return('banana')
-      proxies = [
-        build_proxy(container: @collection1),
-        build_proxy(container: @collection2),
-        build_proxy(container: @parent_object)
-      ]
-      allow(ActiveFedora::Aggregation::Proxy).to receive(:where).with(proxyFor_ssim: @object.id).and_return(proxies)
+      @collection1.ordered_members = [@object]
+      @collection2.ordered_members = [@object]
+      @parent_object.ordered_members = [@object]
+      @parent_object.save
+      @collection1.save
+      @collection2.save
     end
 
     describe 'member_of' do
@@ -469,9 +468,9 @@ describe Hydra::PCDM::Object do
     let(:object4) { described_class.new }
 
     it 'deprecated methods should pass' do
-      expect(object1.members = [object2]).to eq [object2]
-      expect(object1.members << object3).to eq [object2, object3]
-      expect(object1.members += [object4]).to eq [object2, object3, object4]
+      expect(object1.ordered_members = [object2]).to eq [object2]
+      expect(object1.ordered_members << object3).to eq [object2, object3]
+      expect(object1.ordered_members += [object4]).to eq [object2, object3, object4]
       object1.save # required until issue AF-Agg-75 is fixed
       expect(object2.parent_objects).to eq [object1]
       expect(object2.parents).to eq [object1]

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -10,7 +10,7 @@ describe Hydra::PCDM::Object do
       object.ordered_members << child2
     end
 
-    subject { object.object_ids }
+    subject { object.ordered_object_ids }
 
     it { is_expected.to eq %w(1 2) }
   end

--- a/spec/hydra/pcdm/object_indexer_spec.rb
+++ b/spec/hydra/pcdm/object_indexer_spec.rb
@@ -7,7 +7,7 @@ describe Hydra::PCDM::ObjectIndexer do
   let(:indexer)       { described_class.new(object) }
 
   before do
-    allow(object).to receive(:object_ids).and_return([child_object1.id, child_object2.id])
+    allow(object).to receive(:ordered_object_ids).and_return([child_object1.id, child_object2.id])
   end
 
   describe '#generate_solr_document' do


### PR DESCRIPTION
There are a few questions here for me:

1. This assumes #objects/#collections returns those objects and collections which are ORDERED underneath. Is that a bad assumption? Should there be #objects AND #ordered_objects? (Not looking forward to that, but whatcha gonna do)

2. Deleting is different here - you can't just do ordered_members.delete(member), because that member can appear in the ordering multiple times. So I'm using delete_at in the specs - should there be something different?