### PR TITLE
ObjectBehavior#in_objects should return parent objects whether members are added via `members.<<` or `ordered_members.<<`

### DIFF
--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -50,15 +50,5 @@ module Hydra::PCDM
     def pcdm_collection?
       true
     end
-
-    def child_collections
-      warn '[DEPRECATION] `child_collections` is deprecated in Hydra::PCDM.  Please use `collections` instead.  This has a target date for removal of 10-31-2015'
-      ordered_collections
-    end
-
-    def child_collection_ids
-      warn '[DEPRECATION] `child_collection_ids` is deprecated in Hydra::PCDM.  Please use `collection_ids` instead.  This has a target date for removal of 10-31-2015'
-      ordered_collection_ids
-    end
   end
 end

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -40,12 +40,7 @@ module Hydra::PCDM
     end
 
     def in_objects
-      ordered_by.select(&:pcdm_object?).to_a
-    end
-
-    def parent_objects
-      warn '[DEPRECATION] `parent_objects` is deprecated in Hydra::PCDM.  Please use `in_objects` instead.  This has a target date for removal of 10-31-2015'
-      in_objects
+      member_of.select(&:pcdm_object?).to_a
     end
 
     # Returns directly contained files that have the requested RDF Type

--- a/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
@@ -48,27 +48,12 @@ module Hydra::PCDM
       ordered_objects.map(&:id)
     end
 
-    def parents
-      warn '[DEPRECATION] `parents` is deprecated in Hydra::PCDM.  Please use `ordered_by` instead.  This has a target date for removal of 10-31-2015'
-      ordered_by.to_a
-    end
-
     def in_collections
       member_of.select(&:pcdm_collection?).to_a
     end
 
-    def parent_collections
-      warn '[DEPRECATION] `parent_collections` is deprecated in Hydra::PCDM.  Please use `in_collections` instead.  This has a target date for removal of 10-31-2015'
-      in_collections
-    end
-
     def in_collection_ids
       in_collections.map(&:id)
-    end
-
-    def parent_collection_ids
-      warn '[DEPRECATION] `parent_collection_ids` is deprecated in Hydra::PCDM.  Please use `in_collection_ids` instead.  This has a target date for removal of 10-31-2015'
-      in_collection_ids
     end
 
     def ancestor?(record)
@@ -77,16 +62,6 @@ module Hydra::PCDM
 
     def ancestor_checker
       @ancestor_checker ||= ::Hydra::PCDM::AncestorChecker.new(self)
-    end
-
-    def child_objects
-      warn '[DEPRECATION] `child_objects` is deprecated in Hydra::PCDM.  Please use `objects` instead.  This has a target date for removal of 10-31-2015'
-      ordered_objects
-    end
-
-    def child_object_ids
-      warn '[DEPRECATION] `child_object_ids` is deprecated in Hydra::PCDM.  Please use `object_ids` instead.  This has a target date for removal of 10-31-2015'
-      object_ids
     end
   end
 end

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -609,23 +609,4 @@ describe Hydra::PCDM::Collection do
       it { is_expected.to eq IndexingStuff::AltIndexer }
     end
   end
-
-  describe 'make sure deprecated methods still work' do
-    it 'deprecated methods should pass' do
-      collection1.ordered_members = [collection2]
-      expect(collection1.ordered_members << collection3).to eq [collection2, collection3]
-      expect(collection1.ordered_members += [collection4]).to eq [collection2, collection3, collection4]
-      expect(collection1.ordered_members << object1).to eq [collection2, collection3, collection4, object1]
-      expect(collection1.ordered_members << object2).to eq [collection2, collection3, collection4, object1, object2]
-      expect(collection1.ordered_members += [object3]).to eq [collection2, collection3, collection4, object1, object2, object3]
-      collection1.save # required until issue AF-Agg-75 is fixed
-      expect(collection2.parent_collections).to eq [collection1]
-      expect(collection2.parents).to eq [collection1]
-      expect(collection2.parent_collection_ids).to eq [collection1.id]
-      expect(collection1.child_objects).to eq [object1, object2, object3]
-      expect(collection1.child_object_ids).to eq [object1.id, object2.id, object3.id]
-      expect(collection1.child_collections).to eq [collection2, collection3, collection4]
-      expect(collection1.child_collection_ids).to eq [collection2.id, collection3.id, collection4.id]
-    end
-  end
 end

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -151,37 +151,67 @@ describe Hydra::PCDM::Object do
     subject { object.in_objects }
     let(:collection) { Hydra::PCDM::Collection.new }
     let(:parent_object) { described_class.new }
-    before do
-      collection.ordered_members = [object]
-      parent_object.ordered_members = [object]
-      parent_object.save
-      collection.save
-    end
+    context 'using ordered_members' do
+      before do
+        collection.ordered_members = [object]
+        parent_object.ordered_members = [object]
+        parent_object.save
+        collection.save
+      end
 
-    it 'finds objects that aggregate the object' do
-      expect(subject).to eq [parent_object]
+      it 'finds objects that aggregate the object' do
+        expect(subject).to eq [parent_object]
+      end
+    end
+    context 'using members' do
+      before do
+        collection.members = [object]
+        parent_object.members = [object]
+        parent_object.save
+        collection.save
+      end
+
+      it 'finds objects that aggregate the object' do
+        expect(subject).to eq [parent_object]
+      end
     end
   end
 
   describe 'in_collections' do
-    let(:object) { described_class.create }
     subject { object.in_collections }
     let(:object) { described_class.create }
     let(:collection1) { Hydra::PCDM::Collection.new }
     let(:collection2) { Hydra::PCDM::Collection.new }
     let(:parent_object) { described_class.new }
-    before do
-      collection1.ordered_members = [object]
-      collection2.ordered_members = [object]
-      parent_object.ordered_members = [object]
-      parent_object.save
-      collection1.save
-      collection2.save
-    end
+    context 'using ordered_members' do
+      before do
+        collection1.ordered_members = [object]
+        collection2.ordered_members = [object]
+        parent_object.ordered_members = [object]
+        parent_object.save
+        collection1.save
+        collection2.save
+      end
 
-    it 'finds collections that aggregate the object' do
-      expect(subject).to match_array [collection1, collection2]
-      expect(subject.count).to eq 2
+      it 'finds collections that aggregate the object' do
+        expect(subject).to match_array [collection1, collection2]
+        expect(subject.count).to eq 2
+      end
+    end
+    context 'using members' do
+      before do
+        collection1.members = [object]
+        collection2.members = [object]
+        parent_object.members = [object]
+        parent_object.save
+        collection1.save
+        collection2.save
+      end
+
+      it 'finds collections that aggregate the object' do
+        expect(subject).to match_array [collection1, collection2]
+        expect(subject.count).to eq 2
+      end
     end
   end
 
@@ -484,22 +514,6 @@ describe Hydra::PCDM::Object do
 
       subject { Foo.indexer }
       it { is_expected.to eq IndexingStuff::AltIndexer }
-    end
-  end
-
-  describe 'make sure deprecated methods still work' do
-    let(:object1) { described_class.new }
-    let(:object2) { described_class.new }
-    let(:object3) { described_class.new }
-    let(:object4) { described_class.new }
-
-    it 'deprecated methods should pass' do
-      object1.ordered_members = [object2]
-      expect(object1.ordered_members << object3).to eq [object2, object3]
-      expect(object1.ordered_members += [object4]).to eq [object2, object3, object4]
-      object1.save # required until issue AF-Agg-75 is fixed
-      expect(object2.parent_objects).to eq [object1]
-      expect(object2.parents).to eq [object1]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,9 @@ ENV['environment'] ||= 'test'
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [SimpleCov::Formatter::HTMLFormatter,
+   Coveralls::SimpleCov::Formatter])
 SimpleCov.start 'rails'
 
 require 'bundler/setup'


### PR DESCRIPTION
Fixes projecthydra-labs/hydra-works#258

Also, remove all deprecations (four months overdue).