### PR TITLE
Favoring module over class for service methods

### DIFF
--- a/lib/hydra/pcdm/services/file/add_type.rb
+++ b/lib/hydra/pcdm/services/file/add_type.rb
@@ -1,5 +1,5 @@
 module Hydra::PCDM
-  class AddTypeToFile
+  module AddTypeToFile
     # This adds an additional RDF type to an exsiting Hydra::PCDM::File
     #
     # @param [Hydra::PCDM::File] the file object you want to add it to

--- a/lib/hydra/pcdm/services/file/get_mime_type.rb
+++ b/lib/hydra/pcdm/services/file/get_mime_type.rb
@@ -1,5 +1,5 @@
 module Hydra::PCDM
-  class GetMimeTypeForFile
+  module GetMimeTypeForFile
     def self.call(path)
       raise ArgumentError, 'supplied argument should be a path to a file' unless path.is_a?(String)
       mime_types = ::MIME::Types.of(::File.basename(path))


### PR DESCRIPTION
Instead of a class which you can instantiate, favoring a module which
cannot be instantiated. This narrows the interface of the constant.