### PR TITLE
Extracting methods for index key names

### DIFF
--- a/lib/hydra/pcdm.rb
+++ b/lib/hydra/pcdm.rb
@@ -14,6 +14,8 @@ module Hydra
       end
     end
 
+    autoload :Config
+
     # models
     autoload_under 'models' do
       autoload :Collection

--- a/lib/hydra/pcdm/collection_indexer.rb
+++ b/lib/hydra/pcdm/collection_indexer.rb
@@ -2,10 +2,10 @@ module Hydra::PCDM
   class CollectionIndexer < ObjectIndexer
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc['member_ids_ssim'] ||= []
-        solr_doc['member_ids_ssim'] += object.member_ids
-        solr_doc['member_ids_ssim'].uniq!
-        solr_doc['collection_ids_ssim'] = object.ordered_collection_ids
+        solr_doc[Config.indexing_member_ids_key] ||= []
+        solr_doc[Config.indexing_member_ids_key] += object.member_ids
+        solr_doc[Config.indexing_member_ids_key].uniq!
+        solr_doc[Config.indexing_collection_ids_key] = object.ordered_collection_ids
       end
     end
   end

--- a/lib/hydra/pcdm/config.rb
+++ b/lib/hydra/pcdm/config.rb
@@ -1,0 +1,21 @@
+module Hydra
+  module PCDM
+    # A container for configuration options (note configuration is not yet determined).
+    module Config
+      INDEXING_MEMBER_IDS_KEY = 'member_ids_ssim'.freeze
+      def self.indexing_member_ids_key
+        INDEXING_MEMBER_IDS_KEY
+      end
+
+      INDEXING_COLLECTION_IDS_KEY = 'collection_ids_ssim'.freeze
+      def self.indexing_collection_ids_key
+        INDEXING_COLLECTION_IDS_KEY
+      end
+
+      INDEXING_OBJECT_IDS_KEY = 'object_ids_ssim'.freeze
+      def self.indexing_object_ids_key
+        INDEXING_OBJECT_IDS_KEY
+      end
+    end
+  end
+end

--- a/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
@@ -25,7 +25,7 @@ module Hydra::PCDM
 
     def member_of
       return [] if id.nil?
-      ActiveFedora::Base.where(member_ids_ssim: id)
+      ActiveFedora::Base.where(Config.indexing_member_ids_key => id)
     end
 
     def ordered_member_ids

--- a/lib/hydra/pcdm/object_indexer.rb
+++ b/lib/hydra/pcdm/object_indexer.rb
@@ -2,10 +2,10 @@ module Hydra::PCDM
   class ObjectIndexer < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc['member_ids_ssim'] ||= []
-        solr_doc['member_ids_ssim'] += object.member_ids
-        solr_doc['member_ids_ssim'].uniq!
-        solr_doc['object_ids_ssim'] = object.ordered_object_ids
+        solr_doc[Config.indexing_member_ids_key] ||= []
+        solr_doc[Config.indexing_member_ids_key] += object.member_ids
+        solr_doc[Config.indexing_member_ids_key].uniq!
+        solr_doc[Config.indexing_object_ids_key] = object.ordered_object_ids
       end
     end
   end

--- a/spec/hydra/pcdm/collection_indexer_spec.rb
+++ b/spec/hydra/pcdm/collection_indexer_spec.rb
@@ -17,9 +17,9 @@ describe Hydra::PCDM::CollectionIndexer do
     subject { indexer.generate_solr_document }
 
     it 'has fields' do
-      expect(subject['collection_ids_ssim']).to eq %w(123 456)
-      expect(subject['object_ids_ssim']).to eq ['789']
-      expect(subject['member_ids_ssim']).to eq %w(123 456 789)
+      expect(subject[Hydra::PCDM::Config.indexing_collection_ids_key]).to eq %w(123 456)
+      expect(subject[Hydra::PCDM::Config.indexing_object_ids_key]).to eq ['789']
+      expect(subject[Hydra::PCDM::Config.indexing_member_ids_key]).to eq %w(123 456 789)
     end
   end
 end

--- a/spec/hydra/pcdm/config_spec.rb
+++ b/spec/hydra/pcdm/config_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Hydra::PCDM::Config do
+  context '.indexing_member_ids_key' do
+    subject { described_class.indexing_member_ids_key }
+    it { is_expected.to eq(described_class::INDEXING_MEMBER_IDS_KEY) }
+  end
+
+  context '.indexing_collection_ids_key' do
+    subject { described_class.indexing_collection_ids_key }
+    it { is_expected.to eq(described_class::INDEXING_COLLECTION_IDS_KEY) }
+  end
+
+  context '.indexing_object_ids_key' do
+    subject { described_class.indexing_object_ids_key }
+    it { is_expected.to eq(described_class::INDEXING_OBJECT_IDS_KEY) }
+  end
+end

--- a/spec/hydra/pcdm/object_indexer_spec.rb
+++ b/spec/hydra/pcdm/object_indexer_spec.rb
@@ -14,7 +14,7 @@ describe Hydra::PCDM::ObjectIndexer do
     subject { indexer.generate_solr_document }
 
     it 'has fields' do
-      expect(subject['object_ids_ssim']).to eq %w(123 456)
+      expect(subject[Hydra::PCDM::Config.indexing_object_ids_key]).to eq %w(123 456)
     end
   end
 end


### PR DESCRIPTION
Favoring a method over magic string as this allows future
configuration. It is perhaps a bit deceptive to name this Config as it
doesn't expose a configure option. However that is something for a
future concern.

Configuration container options:

* https://github.com/dry-rb/dry-configuration
* ActiveSupport::Configurable

Closes #189