### PR TITLE
Removing memoization of a constant

### DIFF
--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -25,7 +25,7 @@ module Hydra::PCDM
       end
 
       def type_validator
-        @type_validator ||= Validators::PCDMObjectValidator
+        Validators::PCDMObjectValidator
       end
     end
 


### PR DESCRIPTION
Unless there is code accessing the specific class instance variable,
memoization of a constant does not add to any improved performance.
Instead just a bit more memory is required.

Closes #212