### PR TITLE
Adding a PCDMCollectionValidator

### DIFF
--- a/lib/hydra/pcdm/models/concerns/collection_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/collection_behavior.rb
@@ -24,6 +24,7 @@ module Hydra::PCDM
       end
 
       def type_validator
+        Validators::PCDMCollectionValidator
       end
     end
 

--- a/lib/hydra/pcdm/validators.rb
+++ b/lib/hydra/pcdm/validators.rb
@@ -3,6 +3,7 @@ module Hydra::PCDM
     autoload :AncestorValidator,                 'hydra/pcdm/validators/ancestor_validator'
     autoload :PCDMValidator,                     'hydra/pcdm/validators/pcdm_validator'
     autoload :CompositeValidator,                'hydra/pcdm/validators/composite_validator'
+    autoload :PCDMCollectionValidator,           'hydra/pcdm/validators/pcdm_collection_validator'
     autoload :PCDMObjectValidator,               'hydra/pcdm/validators/pcdm_object_validator'
   end
 end

--- a/lib/hydra/pcdm/validators/pcdm_collection_validator.rb
+++ b/lib/hydra/pcdm/validators/pcdm_collection_validator.rb
@@ -1,0 +1,7 @@
+module Hydra::PCDM::Validators
+  class PCDMCollectionValidator
+    def self.validate!(_association, _record)
+      true
+    end
+  end
+end


### PR DESCRIPTION
This validator does nothing more than return true. The overall design
goal is to return a meaningful object with the method call. By
returning `nil` we expect the upstream message sender to jump through
a bit of logic that is analogue to the following:

```ruby
type_validator = Collection.type_validator
if type_validator
  type_validator.validate!(*args)
end
```

Instead, with a type validator that implements a common interface the
message sender can do the following with far greater confidence:

```ruby
Collection.type_validator.validate!(*args)
```

Closes #214